### PR TITLE
fix: quote Mermaid node labels to escape @ and parens (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ Claude Code と Codex を 1 人開発で併用すると、こういうことが�
 
 ```mermaid
 flowchart TD
-    A[Issue 作成] --> B[claude-issue-triage.yml<br/>model: / type: / area: 自動付与]
-    B --> C[着手<br/>status: in-progress]
-    C --> D1[調査・設計<br/>@claude mention → Claude Code]
-    C --> D2[実装<br/>Codex / Claude Code]
-    D1 --> E[PR 作成<br/>status: review-pending]
+    A["Issue 作成"] --> B["claude-issue-triage.yml<br/>model: / type: / area: 自動付与"]
+    B --> C["着手 (status: in-progress)"]
+    C --> D1["調査・設計<br/>@claude mention → Claude Code"]
+    C --> D2["実装<br/>Codex / Claude Code"]
+    D1 --> E["PR 作成 (status: review-pending)"]
     D2 --> E
-    E --> F[claude-pr-review.yml<br/>5 軸レビュー + Learning notes]
-    E --> G[CI: typecheck / build]
-    F --> H[Evidence 提出<br/>status: evidence-required]
+    E --> F["claude-pr-review.yml<br/>5 軸レビュー + Learning notes"]
+    E --> G["CI: typecheck / build"]
+    F --> H["Evidence 提出 (status: evidence-required)"]
     G --> H
-    H --> I{Human 確認<br/>Evidence のみ参照}
-    I -->|OK| J[status: accepted<br/>→ close 人間のみ]
+    H --> I{"Human 確認<br/>Evidence のみ参照"}
+    I -->|OK| J["status: accepted<br/>→ close (人間のみ)"]
     I -->|NG| C
 ```
 


### PR DESCRIPTION
## Summary

PR #16 マージ時に取り込まれなかった quote fix を再投下。
`2a7068e` を cherry-pick（merge commit の parent に含まれず orphan 化していた）。

`@claude` の `@` や括弧を Mermaid が予約トークンとして解釈する問題を回避。
全ノードラベルをダブルクォートで囲む。

Refs #15

## Test plan

- [ ] GitHub UI で README プレビュー、Mermaid 図が parse error なく描画されること
- [ ] ノードテキスト（`@claude` / `(status: ...)` 等）が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)