### PR TITLE
feat(security): Phase 1 — gitleaks + Dependabot + checklist (#18)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,8 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(actions)"
+    # major bump は breaking change が多いので除外。明示的な major 更新は手動で行う。
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - patch
+          - minor
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(actions)"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,22 @@
+name: security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks (secrets)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,40 @@ out/
 .output/
 coverage/
 *.log
-.env
-.env.local
 .DS_Store
+
+# secrets / env
+.env
+.env.*
+!.env.example
+!.env.sample
+
+# private keys / certificates
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks
+id_rsa
+id_ed25519
+id_ecdsa
+
+# service account / credentials
+*-credentials.json
+*-service-account.json
+gcp-key*.json
+aws-credentials*
+
+# DB dumps / backups
+*.sql
+*.sql.gz
+*.dump
+*.bak
+
+# captured traffic / exports
+*.har
+exports/
+dump/
 
 .mcp.json
 .serena/

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ flowchart TD
 | `.github/workflows/claude-issue-triage.yml` | Issue 作成時に model: / type: / area: を自動付与 |
 | `.github/workflows/claude-mention.yml` | @claude メンションで応答（質問 / 調査 / 実装、track_progress 付き） |
 | `.github/workflows/claude-pr-review.yml` | PR 作成時に 5 軸レビュー + Learning notes |
+| `.github/workflows/security.yml` | gitleaks による secret scan（push / PR） |
+| `.github/dependabot.yml` | npm / github-actions の weekly 更新 |
 | `docs/handoff/` | GitHub Issues ベース handoff 運用ガイド + AI 実行制御 |
 | `docs/decisions/` | ADR ひな形 + 参考 ADR（Issue SoT / Human acceptance / Learning loop） |
-| `scripts/` | init-project.sh / commit-msg hook（`#<issue>` 強制）/ sync-labels |
+| `docs/security/public-release-checklist.md` | private→public 化前のセキュリティ確認手順 |
+| `scripts/` | init-project.sh / commit-msg hook（`#<issue>` 強制）/ sync-labels / security-scan.sh |
 
 ---
 

--- a/docs/handoff/bootstrap.md
+++ b/docs/handoff/bootstrap.md
@@ -29,8 +29,12 @@ sh scripts/init-project.sh "<new-pj>" "短い説明"
 `init-project.sh` がやること:
 
 1. `CLAUDE.md` / `AGENTS.md` / `README.md` / `package.json` のプレースホルダ置換
-2. `commit-msg` / `pre-commit` hook をインストール
+2. `commit-msg` / `pre-commit` hook をインストール（pre-commit は staged 差分の secret scan 込み、`gitleaks` 未インストールでも commit はブロックしない）
 3. `.github/labels.yml` を GitHub に同期（`status:` 7種 + `model:` 3種 + `cost: overrun` 等）
+
+### Security CI（自動）
+
+`.github/workflows/security.yml`（gitleaks）と `.github/dependabot.yml`（npm + github-actions weekly）がデフォルト有効。public 化前は [`docs/security/public-release-checklist.md`](../security/public-release-checklist.md) を必ず通す。
 
 ---
 

--- a/docs/security/public-release-checklist.md
+++ b/docs/security/public-release-checklist.md
@@ -1,0 +1,117 @@
+# Public Release Checklist
+
+private repo を public 化する前に必ず通すチェックリスト。
+**一度でも Git に入った secret は削除ではなく失効・再発行が原則**。push して履歴に入った時点で「漏洩した」と扱う。
+
+---
+
+## 1. Secret scan（必須）
+
+### 1.1 working tree
+
+```sh
+sh scripts/security-scan.sh --full
+```
+
+### 1.2 git history 全体
+
+```sh
+sh scripts/security-scan.sh --history
+```
+
+### 1.3 手動 grep（gitleaks 漏れ対策）
+
+API key prefix / JWT / PEM ヘッダ等の典型パターン:
+
+```sh
+git log -p --all -S 'BEGIN PRIVATE KEY' -- '*.pem' '*.key'
+git log -p --all -S 'AKIA' -- ':!*.lock'             # AWS access key
+git log -p --all -S 'AIza'                            # Google API key
+git log -p --all -S 'ghp_'                            # GitHub PAT
+git log -p --all -S 'sk-' -- ':!*.lock'              # OpenAI / Anthropic
+git log -p --all -S 'eyJ' | head -200                # JWT (base64 header)
+```
+
+検出された場合: **削除ではなく失効・再発行**。`git filter-repo` で履歴書き換えする場合も、まず secret を rotate してから。
+
+---
+
+## 2. GitHub 上のアセット
+
+`gh` CLI で公開される全要素を点検:
+
+```sh
+# Issue / PR 本文・コメント（過去に貼り付け事故）
+gh issue list --state all --limit 200 --json number,title,body
+gh pr list   --state all --limit 200 --json number,title,body
+# コメントは個別に: gh api repos/<owner>/<repo>/issues/<n>/comments
+
+# Workflow runs / artifacts / logs
+gh run list --limit 100
+gh api repos/<owner>/<repo>/actions/artifacts --jq '.artifacts[] | {id,name}'
+
+# Releases assets
+gh release list
+
+# Packages（GHCR / npm 等）
+gh api /users/<owner>/packages
+
+# Wiki / Discussions / Pages
+# UI で確認 + git clone <repo>.wiki.git
+```
+
+artifact / log に secret が含まれた可能性があれば **削除 + secret rotate**。
+
+---
+
+## 3. ローカル / 設定ファイル
+
+| ファイル | 確認内容 |
+|---|---|
+| `.env*` | `.gitignore` に入って untracked か |
+| `.mcp.json` | MCP サーバー設定に API key 直書きないか |
+| `.claude/settings.local.json` | 個人 username / token / 絶対パス |
+| `.vscode/settings.json` | secret や個人パス |
+| `*.har` / `exports/` | 通信ログに認証 header / cookie |
+| `coverage/` `dist/` | bundle 内に .env 内容が混入 |
+
+```sh
+git ls-files | grep -E '\.(env|pem|key|har)$|credentials|secret'
+```
+
+---
+
+## 4. 実データ
+
+- **DB dump** (`*.sql` `*.dump`) — 個人情報・本番データなし
+- **fixture / seed** — 実顧客データを含むテストデータなし
+- **screenshot / 動画** — 画面に token / 顧客名が映ってない
+
+---
+
+## 5. AI / agent 設定
+
+| 確認対象 | 内容 |
+|---|---|
+| `CLAUDE.md` / `AGENTS.md` | 社内固有名詞・URL・人名 |
+| `.claude/rules/` | path-scoped rules に内部情報 |
+| `prompt cache` / chat log の commit | 過去会話の貼り付けなし |
+
+---
+
+## 6. 公開直前
+
+- [ ] `git log --oneline | wc -l` で履歴サイズ確認（過剰なら squash 検討）
+- [ ] `LICENSE` 存在
+- [ ] `SECURITY.md` の報告先が現役
+- [ ] README の連絡先が個人 mail 直書きでない
+- [ ] Settings → Manage access で意図しない collaborator なし
+- [ ] Branch protection（main への direct push 禁止 / 必須レビュー）
+
+---
+
+## 7. 公開後
+
+- [ ] 1 週間後: `gh api repos/<owner>/<repo>/traffic/clones` でアクセス監視
+- [ ] gitleaks workflow が PR 毎に走っていること（[`.github/workflows/security.yml`](../../.github/workflows/security.yml)）
+- [ ] dependabot PR が来たらマージ運用

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -2,11 +2,25 @@
 # pre-commit hook
 # install with: sh scripts/setup-hooks.sh
 
-npm run precommit:check
-
-if [ $? -ne 0 ]; then
+# 1. secret scan (staged diff)
+#    gitleaks 未インストールでも commit はブロックしない（warn のみ）
+sh scripts/security-scan.sh --staged
+rc=$?
+if [ $rc -eq 1 ]; then
   echo ""
-  echo "Pre-commit checks failed."
-  echo "  Fix typecheck errors (or whatever precommit:check runs) and commit again."
+  echo "Pre-commit: secrets detected in staged changes."
+  echo "  Remove the secret, then commit again."
+  echo "  If accidentally committed earlier, ROTATE the secret (do not just delete)."
   exit 1
+fi
+
+# 2. project-specific check（Node なら typecheck 等、未設定なら no-op）
+if [ -f package.json ] && command -v npm >/dev/null 2>&1; then
+  npm run precommit:check
+  if [ $? -ne 0 ]; then
+    echo ""
+    echo "Pre-commit checks failed."
+    echo "  Fix the errors and commit again."
+    exit 1
+  fi
 fi

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# security-scan.sh
+# ローカル security scan ラッパー。CI と同じ検出器をローカルでも回せる。
+#
+# モード:
+#   --staged    staged diff のみ scan（pre-commit hook 用）
+#   --full      working tree 全体 scan（手動確認用、デフォルト）
+#   --history   git history 全 commit scan（公開前確認用、重い）
+#
+# 動作:
+#   - gitleaks がインストールされていれば実行
+#   - 未インストール時:
+#       * pre-commit (--staged) → warn のみ、exit 0（commit ブロックしない）
+#       * それ以外           → エラー終了 exit 2（CI と人間用）
+#   - leak 検出時は exit 1
+#
+# CI 環境（$CI=true）では未インストールも exit 1。
+
+set -eu
+
+MODE="${1:---full}"
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  case "$MODE" in
+    --staged)
+      echo "[security-scan] gitleaks not installed — skipping pre-commit secret scan." >&2
+      echo "[security-scan]   Install: https://github.com/gitleaks/gitleaks#installing" >&2
+      exit 0
+      ;;
+    *)
+      echo "[security-scan] gitleaks not installed." >&2
+      echo "[security-scan]   Install: https://github.com/gitleaks/gitleaks#installing" >&2
+      [ "${CI:-false}" = "true" ] && exit 1
+      exit 2
+      ;;
+  esac
+fi
+
+case "$MODE" in
+  --staged)
+    echo "[security-scan] gitleaks: staged diff scan"
+    gitleaks protect --staged --no-banner --redact
+    ;;
+  --full)
+    echo "[security-scan] gitleaks: working tree scan"
+    gitleaks dir --no-banner --redact .
+    ;;
+  --history)
+    echo "[security-scan] gitleaks: full git history scan"
+    gitleaks git --no-banner --redact .
+    ;;
+  *)
+    echo "[security-scan] unknown mode: $MODE" >&2
+    echo "Usage: $0 [--staged | --full | --history]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

個人開発の軽さ最優先で security CI MVP を導入。

- **gitleaks workflow** — push / PR / dispatch、permissions 最小化（contents:read）
- **Dependabot** — npm + github-actions weekly、PR 上限 5、dev/prod groups
- **security-scan.sh** — `--staged` / `--full` / `--history` の3モード。gitleaks 未インストール時は pre-commit ではブロックしないが、CI / 手動実行時はエラー
- **pre-commit hook** — staged secret scan を追加。Node 以外の PJ でも壊れないよう `npm precommit:check` は条件分岐
- **.gitignore** — `.env.*` / 秘密鍵 / credentials / DB dump / HAR / exports 除外（`.env.example` は許可）
- **public-release-checklist.md** — 履歴 grep / Issues / artifacts / wiki / 実データ / AI 設定。**Git に入った secret は失効・再発行が原則**

Trivy / CodeQL は意図的に out of scope（個人テンプレの軽さ優先）。

Closes #18
Refs #19 #20

## Test plan

- [ ] gitleaks workflow が PR で SUCCESS になる（このテンプレ自身に leak なし）
- [ ] `sh scripts/security-scan.sh --full` ローカルで実行（gitleaks 未インストール時は warn）
- [ ] `sh scripts/security-scan.sh --staged` ローカル（pre-commit シミュレーション、未インストールでも exit 0）
- [ ] dummy fake secret を staged して pre-commit fail を確認、unstage（gitleaks インストール環境のみ）
- [ ] Dependabot 設定が GitHub UI で valid 認識される

🤖 Generated with [Claude Code](https://claude.com/claude-code)