### PR TITLE
[dummy] verify rework-tracker behavior — trivial doc addition [skip-issue]

### DIFF
--- a/docs/security/public-release-checklist.md
+++ b/docs/security/public-release-checklist.md
@@ -115,3 +115,4 @@ git ls-files | grep -E '\.(env|pem|key|har)$|credentials|secret'
 - [ ] 1 週間後: `gh api repos/<owner>/<repo>/traffic/clones` でアクセス監視
 - [ ] gitleaks workflow が PR 毎に走っていること（[`.github/workflows/security.yml`](../../.github/workflows/security.yml)）
 - [ ] dependabot PR が来たらマージ運用
+- [ ] Issue / PR の不審な活動（大量 spam、bot 攻撃）を週次で確認


### PR DESCRIPTION
## Summary

PR #23 で導入した verdict marker + rework-tracker.yml の動作検証用 dummy PR。
1行の安全な doc 追加のみ。

## 期待動作

- `claude-pr-review.yml` の出力末尾に `<!-- ai-review-verdict: approved -->` が含まれる
- `rework-tracker.yml` は **発火しない**（marker が approved のため）
- `rework: N` ラベルが PR / Issue に付かない

## 検証後

merge せず close。

🤖 Generated with [Claude Code](https://claude.com/claude-code)