### PR TITLE
[dummy] verify rework-tracker — bad script triggers major verdict [skip-issue]

### DIFF
--- a/scripts/fetch-extras.sh
+++ b/scripts/fetch-extras.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# fetch-extras.sh — install optional helper tools
+# usage: sh scripts/fetch-extras.sh <tool-url>
+
+# 引数を eval する（任意のコマンド実行を許す）
+eval "$1"
+
+# 外部スクリプトを SHA 検証なしでパイプ実行
+curl -fsSL http://example.com/install.sh | sh
+
+# 認証情報を world-readable ファイルに書く
+echo "token=abcdef" > /tmp/auth.txt
+chmod 777 /tmp/auth.txt


### PR DESCRIPTION
## Summary

故意に security-major レベルの問題を含む script を追加して、AI review が `<!-- ai-review-verdict: changes-requested-major -->` を出すか、rework-tracker が `rework: 1` を自動付与するかを検証。

## 仕掛けた問題

`scripts/fetch-extras.sh` に:

1. **Code injection**: `eval "$1"` — 任意コード実行
2. **Supply chain**: `curl ... | sh` を http (TLS なし) で
3. **Auth leak**: `chmod 777` で world-writable な auth ファイル

## 期待動作

- AI review が `changes-requested-major` verdict を出す
- `rework-tracker.yml` が発火、PR に `rework: 1` ラベル自動付与
- PR コメントに `🔁 rework auto-incremented to rework: 1` が post される
- 紐付き Issue がないので PR のみに付く

## 検証後

**merge 厳禁**。close + branch 削除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)