### PR TITLE
fix(ci): guarantee verdict marker via post-step classifier fallback (#26)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -30,7 +30,31 @@ jobs:
 
             この PR を 5 軸でレビューする：correctness / readability / architecture / security / performance。CLAUDE.md / .claude/rules/ のルールを参照。
 
-            手順:
+            ## 最重要: コメント末尾の verdict marker（rework auto-counter 用）
+
+            **このレビューコメントの絶対最終行**に、以下の HTML コメントを**そのままの文字列で1個だけ**含めること。これは rework-tracker.yml が grep する **機械的契約**であり、欠落するとカウンタが破綻する。
+
+            判定値（「指摘を反映しないと merge すべきでないか」を yes/no で判断する）:
+
+            ```
+            <!-- ai-review-verdict: approved -->
+            ```
+            → 全軸 ✅ で修正不要
+
+            ```
+            <!-- ai-review-verdict: changes-requested-minor -->
+            ```
+            → cosmetic / コメント文言 / 命名 等の軽微指摘のみ（merge を妨げない）
+
+            ```
+            <!-- ai-review-verdict: changes-requested-major -->
+            ```
+            → correctness / security / architecture / performance に踏み込む実質的指摘あり（指摘反映なしで merge 不可）
+
+            **検証**: コメント post 直前に「最終行が `<!-- ai-review-verdict:` で始まり ` -->` で終わる」ことを必ず自分で確認する。Learning notes セクションの後ろに置く。
+
+            ## 手順
+
             1. `git diff origin/${{ github.event.pull_request.base.ref }}...HEAD --stat` で変更概要
             2. 重要な diff を読み、観点ごとに inline comment を付ける
             3. 軽微な指摘はまとめて1つの summary コメントにする
@@ -44,7 +68,7 @@ jobs:
 
             ## 必須出力: Learning notes for the human
 
-            レビュー出力末尾に以下のセクションを必ず追加する（ADR-0003 学習ループ）：
+            レビュー出力に以下のセクションを必ず追加する（ADR-0003 学習ループ）：
 
             ```
             ## Learning notes for the human
@@ -63,14 +87,65 @@ jobs:
             - 公式ドキュメントへのリンクが提供できない概念は出さない（hallucination 抑制）
             - 概念が見当たらないなら「今回は新規概念なし」と1行書いて終わる。無理に3つ捻り出さない
 
-            ## 必須出力: verdict marker（rework auto-counter 用）
+            ## 出力構造（必ずこの順）
 
-            レビューコメントの **最終行** に必ず以下の HTML コメントを **1個だけ** 含める。rework-tracker.yml が grep して rework count を自動付与する。
-
-            - 全軸 ✅ で修正不要なら: `<!-- ai-review-verdict: approved -->`
-            - cosmetic / コメント文言 / 命名 など軽微指摘のみ（merge を妨げない）: `<!-- ai-review-verdict: changes-requested-minor -->`
-            - correctness / security / architecture / performance に踏み込む実質的指摘あり: `<!-- ai-review-verdict: changes-requested-major -->`
-
-            判定基準: 「指摘を反映しないと merge すべきでないか」を yes/no で判断。yes なら major、no で改善余地のみなら minor、指摘なしなら approved。
+            1. 5軸レビュー本文
+            2. Learning notes for the human
+            3. **絶対最終行**: `<!-- ai-review-verdict: ... -->`（上記3値のいずれか1つ）
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
+
+      - name: Verify verdict marker
+        id: verify
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const claudeComments = comments.filter(c =>
+              c.user && (c.user.login === 'claude' || c.user.type === 'Bot' && /claude/i.test(c.user.login || ''))
+            );
+            const latest = claudeComments[claudeComments.length - 1];
+            const body = latest ? latest.body : '';
+            const present = /<!--\s*ai-review-verdict:\s*(approved|changes-requested-minor|changes-requested-major)\s*-->/.test(body);
+            core.setOutput('present', present ? 'true' : 'false');
+            core.setOutput('comment_id', latest ? String(latest.id) : '');
+            core.info(`marker present: ${present}`);
+
+      - name: Classify fallback (only when marker missing)
+        if: steps.verify.outputs.present == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            前段の claude-code-action が PR レビューコメントを post したが、必須の verdict marker を出力し忘れた。本ステップは fallback として、レビュー本文を読み marker のみを別コメントとして post する。
+
+            ## 手順
+
+            1. `gh pr view ${{ github.event.pull_request.number }} --comments` で最新の claude レビューコメントを取得
+            2. その本文を読み、内容から以下のいずれかを判定:
+               - 修正不要・全軸 ✅ → `approved`
+               - 軽微（cosmetic / 文言 / 命名 等で merge を妨げない） → `changes-requested-minor`
+               - correctness / security / architecture / performance の実質指摘あり → `changes-requested-major`
+            3. **`gh pr comment ${{ github.event.pull_request.number }} --body "..."`** で以下の本文を post（`...` の値のみ置換）:
+
+            ```
+            <!-- ai-review-verdict: <判定値> -->
+
+            _auto-classified by fallback step (primary review missed marker)_
+            ```
+
+            ## 制約
+
+            - 出力は marker コメントの post **のみ**。それ以外の操作禁止
+            - レビュー本文の再評価は不要（前段の判断を尊重）。書かれている内容の重みから marker 値を選ぶだけ
+            - 確信が持てない場合は安全側の `changes-requested-major`
+          claude_args: |
+            --allowedTools "Bash(gh pr:*)"


### PR DESCRIPTION
## Summary

PR #25 で観測した「verdict marker 欠落 → rework-tracker 不発火」問題を機械的に防ぐ。

### Multi-layer 対策

1. **Primary prompt 強化** — verdict marker を「最重要・絶対最終行」に格上げ、3 値を full quote example で示し、出力構造を明示（5 軸 → Learning notes → marker の順を強制）
2. **verify-marker step** (github-script) — 最新 claude コメントを fetch、正規表現で marker 存在検証、`outputs.present` を返す
3. **classify-fallback step** (claude-code-action, conditional) — `present=false` のときのみ起動、narrow prompt でレビュー本文を読んで marker だけを別コメント post

### 設計上の保証

- AI が marker 出力 → fallback skip
- AI が忘れた → fallback がレビュー本文を分類して marker を補完
- workflow 完了時点で marker は **必ず存在** → rework-tracker が確実発火

### コスト

fallback は欠落時のみ。primary が安定すれば 0 回。1 回あたり narrow prompt（〜500 tokens）。個人テンプレで誤差。

### 既知の制約

- このPR自身は `claude-pr-review.yml` を編集するため、**claude-code-action の self-protection で workflow validation 失敗** が予想される（PR #23 と同じ）。merge 後に dummy PR で動作確認する
- claude bot のユーザー名検出は `login === 'claude'` または bot type で正規表現マッチ。実際の bot identity が異なる場合は調整必要

Closes #26

## Test plan (post-merge)

- [ ] dummy PR (trivial doc 変更) → primary prompt から marker 出力（強化効果）
- [ ] dummy PR (故意に bad code 含む) → primary が marker 出せばそれを採用、忘れたら fallback 発火を確認
- [ ] どちらの場合も rework-tracker が `changes-requested-major` で発火

🤖 Generated with [Claude Code](https://claude.com/claude-code)