### PR TITLE
[dummy] verify #27 fix — bad script must trigger marker + rework-tracker [skip-issue]

### DIFF
--- a/scripts/fetch-extras.sh
+++ b/scripts/fetch-extras.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# fetch-extras.sh — install optional helper tools
+# usage: sh scripts/fetch-extras.sh <tool-url>
+
+# 引数を eval する（任意のコマンド実行を許す）
+eval "$1"
+
+# 外部スクリプトを SHA 検証なしでパイプ実行
+curl -fsSL http://example.com/install.sh | sh
+
+# 認証情報を world-readable ファイルに書く
+echo "token=abcdef" > /tmp/auth.txt
+chmod 777 /tmp/auth.txt


### PR DESCRIPTION
## Summary

PR #27 で導入した primary prompt 強化 + classify-fallback step が機能するか検証。

PR #25 と同じ仕掛け script（eval / curl|sh / chmod 777）を再投入。

## 期待動作

A. **primary が marker 出した場合**:
   - レビュー本文末尾に `<!-- ai-review-verdict: changes-requested-major -->` 含む
   - verify-marker step が `present=true` で fallback skip
   - rework-tracker 発火 → PR に `rework: 1` ラベル + auto-increment コメント

B. **primary が忘れた場合**:
   - verify-marker step が `present=false`
   - classify-fallback step 起動、narrow prompt で marker のみ別コメント post
   - rework-tracker が fallback コメントを拾って発火 → 同じ結果

どちらの経路でも **marker は必ず存在 + rework-tracker 確実発火** が達成されているか確認。

## 検証後

merge 厳禁。close + branch 削除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)