### PR TITLE
feat(ci): security Phase 2 — Trivy + shellcheck (#19)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force LF for shell scripts and git hooks (avoid SC1017 on Windows checkout)
+*.sh text eol=lf
+scripts/pre-commit text eol=lf
+scripts/commit-msg text eol=lf
+*.mjs text eol=lf

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,9 +33,10 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: "1"
           ignore-unfixed: true
+          cache: true
 
   shellcheck:
-    name: shellcheck (*.sh)
+    name: shellcheck (shell scripts)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,3 +20,25 @@ jobs:
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  trivy:
+    name: trivy (vuln + misconfig)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          scan-type: fs
+          scanners: vuln,misconfig
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          ignore-unfixed: true
+
+  shellcheck:
+    name: shellcheck (*.sh)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
+        with:
+          severity: warning

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ flowchart TD
 | `.github/workflows/claude-mention.yml` | @claude メンションで応答（質問 / 調査 / 実装、track_progress 付き） |
 | `.github/workflows/claude-pr-review.yml` | PR 作成時に 5 軸レビュー + Learning notes + verdict marker |
 | `.github/workflows/rework-tracker.yml` | AI review の `changes-requested-major` を検知して `rework: N` を自動加算 |
-| `.github/workflows/security.yml` | gitleaks による secret scan（push / PR） |
+| `.github/workflows/security.yml` | gitleaks (secret) / Trivy (vuln+misconfig) / shellcheck (shell lint) を並列実行 |
 | `.github/dependabot.yml` | npm / github-actions の weekly 更新 |
 | `docs/handoff/` | GitHub Issues ベース handoff 運用ガイド + AI 実行制御 |
 | `docs/decisions/` | ADR ひな形 + 参考 ADR（Issue SoT / Human acceptance / Learning loop） |

--- a/docs/handoff/bootstrap.md
+++ b/docs/handoff/bootstrap.md
@@ -34,7 +34,9 @@ sh scripts/init-project.sh "<new-pj>" "短い説明"
 
 ### Security CI（自動）
 
-`.github/workflows/security.yml`（gitleaks）と `.github/dependabot.yml`（npm + github-actions weekly）がデフォルト有効。public 化前は [`docs/security/public-release-checklist.md`](../security/public-release-checklist.md) を必ず通す。
+`.github/workflows/security.yml` で **gitleaks**（secret）/ **Trivy**（dep vuln + IaC misconfig、HIGH/CRITICAL のみ）/ **shellcheck**（shell lint、warning level）を並列実行。`.github/dependabot.yml`（npm + github-actions weekly）も併走。
+
+ローカルで同等 scan するには `sh scripts/security-scan.sh --all`（各ツール個別実行は `--trivy` / `--shellcheck` 等）。public 化前は [`docs/security/public-release-checklist.md`](../security/public-release-checklist.md) を必ず通す。
 
 ---
 

--- a/docs/security/public-release-checklist.md
+++ b/docs/security/public-release-checklist.md
@@ -113,6 +113,6 @@ git ls-files | grep -E '\.(env|pem|key|har)$|credentials|secret'
 ## 7. 公開後
 
 - [ ] 1 週間後: `gh api repos/<owner>/<repo>/traffic/clones` でアクセス監視
-- [ ] gitleaks workflow が PR 毎に走っていること（[`.github/workflows/security.yml`](../../.github/workflows/security.yml)）
+- [ ] security workflow（gitleaks / Trivy / shellcheck）が PR 毎に走っていること（[`.github/workflows/security.yml`](../../.github/workflows/security.yml)）
 - [ ] dependabot PR が来たらマージ運用
 - [ ] Issue / PR の不審な活動（大量 spam、bot 攻撃）を週次で確認

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -6,7 +6,7 @@
 #    gitleaks 未インストールでも commit はブロックしない（warn のみ）
 sh scripts/security-scan.sh --staged
 rc=$?
-if [ $rc -eq 1 ]; then
+if [ "$rc" -eq 1 ]; then
   echo ""
   echo "Pre-commit: secrets detected in staged changes."
   echo "  Remove the secret, then commit again."
@@ -16,8 +16,7 @@ fi
 
 # 2. project-specific check（Node なら typecheck 等、未設定なら no-op）
 if [ -f package.json ] && command -v npm >/dev/null 2>&1; then
-  npm run precommit:check
-  if [ $? -ne 0 ]; then
+  if ! npm run precommit:check; then
     echo ""
     echo "Pre-commit checks failed."
     echo "  Fix the errors and commit again."

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -1,59 +1,101 @@
 #!/usr/bin/env bash
 # security-scan.sh
-# ローカル security scan ラッパー。CI と同じ検出器をローカルでも回せる。
+# Local security scan wrapper. CI と同じ検出器をローカルで回せる。
 #
 # モード:
-#   --staged    staged diff のみ scan（pre-commit hook 用）
-#   --full      working tree 全体 scan（手動確認用、デフォルト）
-#   --history   git history 全 commit scan（公開前確認用、重い）
+#   --staged       gitleaks: staged diff のみ（pre-commit 用）
+#   --full         gitleaks: working tree 全体（デフォルト）
+#   --history      gitleaks: 全 git history
+#   --trivy        Trivy: fs scan（vuln + misconfig、HIGH/CRITICAL）
+#   --shellcheck   shellcheck: *.sh + shebang 検出 shell ファイル（warning level）
+#   --all          gitleaks(--full) + Trivy + shellcheck
 #
-# 動作:
-#   - gitleaks がインストールされていれば実行
-#   - 未インストール時:
-#       * pre-commit (--staged) → warn のみ、exit 0（commit ブロックしない）
-#       * それ以外           → エラー終了 exit 2（CI と人間用）
-#   - leak 検出時は exit 1
-#
-# CI 環境（$CI=true）では未インストールも exit 1。
+# ツール未インストール時:
+#   --staged + gitleaks 欠落 → warn + exit 0（commit ブロックしない）
+#   それ以外                  → exit 2（CI=true なら exit 1）
 
 set -eu
 
 MODE="${1:---full}"
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-cd "$ROOT"
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
-if ! command -v gitleaks >/dev/null 2>&1; then
-  case "$MODE" in
-    --staged)
-      echo "[security-scan] gitleaks not installed — skipping pre-commit secret scan." >&2
-      echo "[security-scan]   Install: https://github.com/gitleaks/gitleaks#installing" >&2
-      exit 0
-      ;;
-    *)
-      echo "[security-scan] gitleaks not installed." >&2
-      echo "[security-scan]   Install: https://github.com/gitleaks/gitleaks#installing" >&2
-      [ "${CI:-false}" = "true" ] && exit 1
-      exit 2
-      ;;
-  esac
-fi
+require_tool() {
+  if command -v "$1" >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "[security-scan] $1 not installed." >&2
+  echo "[security-scan]   Install: $2" >&2
+  if [ "${CI:-false}" = "true" ]; then
+    return 1
+  fi
+  return 2
+}
+
+run_gitleaks_staged() {
+  if ! command -v gitleaks >/dev/null 2>&1; then
+    echo "[security-scan] gitleaks not installed — skipping pre-commit secret scan." >&2
+    echo "[security-scan]   Install: https://github.com/gitleaks/gitleaks#installing" >&2
+    return 0
+  fi
+  echo "[security-scan] gitleaks: staged diff"
+  gitleaks protect --staged --no-banner --redact
+}
+
+run_gitleaks_dir() {
+  require_tool gitleaks https://github.com/gitleaks/gitleaks#installing || return $?
+  echo "[security-scan] gitleaks: working tree"
+  gitleaks dir --no-banner --redact .
+}
+
+run_gitleaks_git() {
+  require_tool gitleaks https://github.com/gitleaks/gitleaks#installing || return $?
+  echo "[security-scan] gitleaks: full history"
+  gitleaks git --no-banner --redact .
+}
+
+run_trivy() {
+  require_tool trivy https://aquasecurity.github.io/trivy/latest/getting-started/installation/ || return $?
+  echo "[security-scan] trivy: fs scan (vuln+misconfig, HIGH/CRITICAL)"
+  trivy fs --scanners vuln,misconfig --severity HIGH,CRITICAL --exit-code 1 --ignore-unfixed .
+}
+
+run_shellcheck() {
+  require_tool shellcheck https://github.com/koalaman/shellcheck#installing || return $?
+  echo "[security-scan] shellcheck: *.sh + shebang-detected shell files (warning level)"
+  files=$(
+    {
+      find . -type f -name '*.sh' \
+        -not -path './.git/*' \
+        -not -path './node_modules/*' 2>/dev/null
+      grep -rlE '^#!\s*(/bin/|/usr/bin/env[[:space:]]+)((ba|da|k|z)?sh)' . \
+        --exclude-dir=.git \
+        --exclude-dir=node_modules \
+        --exclude-dir=.github 2>/dev/null || true
+    } | sort -u
+  )
+  if [ -z "$files" ]; then
+    echo "[security-scan]   no shell files found"
+    return 0
+  fi
+  echo "$files" | xargs shellcheck -S warning
+}
 
 case "$MODE" in
-  --staged)
-    echo "[security-scan] gitleaks: staged diff scan"
-    gitleaks protect --staged --no-banner --redact
-    ;;
-  --full)
-    echo "[security-scan] gitleaks: working tree scan"
-    gitleaks dir --no-banner --redact .
-    ;;
-  --history)
-    echo "[security-scan] gitleaks: full git history scan"
-    gitleaks git --no-banner --redact .
+  --staged)     run_gitleaks_staged ;;
+  --full)       run_gitleaks_dir ;;
+  --history)    run_gitleaks_git ;;
+  --trivy)      run_trivy ;;
+  --shellcheck) run_shellcheck ;;
+  --all)
+    rc=0
+    run_gitleaks_dir || rc=$?
+    run_trivy        || rc=$?
+    run_shellcheck   || rc=$?
+    exit "$rc"
     ;;
   *)
     echo "[security-scan] unknown mode: $MODE" >&2
-    echo "Usage: $0 [--staged | --full | --history]" >&2
+    echo "Usage: $0 [--staged | --full | --history | --trivy | --shellcheck | --all]" >&2
     exit 2
     ;;
 esac

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -76,12 +76,9 @@ _list_shell_files_z() {
 run_shellcheck() {
   require_tool shellcheck https://github.com/koalaman/shellcheck#installing || return $?
   echo "[security-scan] shellcheck: *.sh + shebang-detected shell files (warning level)"
-  list=$(_list_shell_files_z)
-  if [ -z "$list" ]; then
-    echo "[security-scan]   no shell files found"
-    return 0
-  fi
-  printf '%s' "$list" | xargs -0 shellcheck -S warning
+  # $() で受けると NUL バイトが消えて xargs -0 が壊れるため直接パイプする。
+  # xargs -r (GNU) で空入力時に shellcheck を呼ばない。
+  _list_shell_files_z | xargs -0 -r shellcheck -S warning
 }
 
 case "$MODE" in

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # security-scan.sh
-# Local security scan wrapper. CI と同じ検出器をローカルで回せる。
+# ローカル security scan ラッパー。CI と同じ検出器をローカルで回せる。
 #
 # モード:
 #   --staged       gitleaks: staged diff のみ（pre-commit 用）
@@ -59,25 +59,29 @@ run_trivy() {
   trivy fs --scanners vuln,misconfig --severity HIGH,CRITICAL --exit-code 1 --ignore-unfixed .
 }
 
+_list_shell_files_z() {
+  # NUL-separated to handle spaces / unusual chars in filenames
+  {
+    find . -type f -name '*.sh' \
+      -not -path './.git/*' \
+      -not -path './node_modules/*' \
+      -not -path './.github/*' -print0 2>/dev/null
+    grep -rlZE '^#!\s*(/bin/|/usr/bin/env[[:space:]]+)((ba|da|k|z)?sh)' . \
+      --exclude-dir=.git \
+      --exclude-dir=node_modules \
+      --exclude-dir=.github 2>/dev/null || true
+  } | sort -zu
+}
+
 run_shellcheck() {
   require_tool shellcheck https://github.com/koalaman/shellcheck#installing || return $?
   echo "[security-scan] shellcheck: *.sh + shebang-detected shell files (warning level)"
-  files=$(
-    {
-      find . -type f -name '*.sh' \
-        -not -path './.git/*' \
-        -not -path './node_modules/*' 2>/dev/null
-      grep -rlE '^#!\s*(/bin/|/usr/bin/env[[:space:]]+)((ba|da|k|z)?sh)' . \
-        --exclude-dir=.git \
-        --exclude-dir=node_modules \
-        --exclude-dir=.github 2>/dev/null || true
-    } | sort -u
-  )
-  if [ -z "$files" ]; then
+  list=$(_list_shell_files_z)
+  if [ -z "$list" ]; then
     echo "[security-scan]   no shell files found"
     return 0
   fi
-  echo "$files" | xargs shellcheck -S warning
+  printf '%s' "$list" | xargs -0 shellcheck -S warning
 }
 
 case "$MODE" in
@@ -87,11 +91,26 @@ case "$MODE" in
   --trivy)      run_trivy ;;
   --shellcheck) run_shellcheck ;;
   --all)
-    rc=0
-    run_gitleaks_dir || rc=$?
-    run_trivy        || rc=$?
-    run_shellcheck   || rc=$?
-    exit "$rc"
+    # last-wins だと issue 検出(1) が tool 欠落(2) で隠れるため、両者を別管理する
+    found_issues=0
+    missing_tools=0
+    for fn in run_gitleaks_dir run_trivy run_shellcheck; do
+      if "$fn"; then
+        :
+      else
+        case $? in
+          1) found_issues=1 ;;
+          2) missing_tools=1 ;;
+          *) found_issues=1 ;;
+        esac
+      fi
+    done
+    if [ "$found_issues" = "1" ]; then
+      exit 1
+    elif [ "$missing_tools" = "1" ]; then
+      exit 2
+    fi
+    exit 0
     ;;
   *)
     echo "[security-scan] unknown mode: $MODE" >&2


### PR DESCRIPTION
## Summary

Phase 1 (#18 gitleaks + Dependabot) の **取りこぼし**（PR #28 で実証: gitleaks は `eval` / `curl|sh` / `chmod 777` を見逃す）を Trivy + shellcheck で埋める。

### 追加内容

- **`security.yml` 並列 job 拡張**
  - `trivy` (aquasecurity/trivy-action@ed142fd  v0.36.0): fs scan、`vuln,misconfig` 限定、`HIGH,CRITICAL`、`ignore-unfixed`
  - `shellcheck` (ludeeus/action-shellcheck@00cae50  2.0.0): warning level（教育効果込み）
  - 既存 gitleaks job と並列実行
- **`security-scan.sh` リファクタ**: `--trivy` / `--shellcheck` / `--all` モード追加。各ツール独立に missing-warn、CI=true で exit 1 にエスカレート
- **`pre-commit`**: SC2181 修正（`$?` チェック → `if !...`）、quote 追加
- **`.gitattributes` 新規**: shell/mjs を eol=lf 固定（Windows checkout で CRLF 化された shell が手元 shellcheck で SC1017 誤検知する問題を予防）
- **docs**: README 表 / bootstrap.md / public-release-checklist.md を更新

### CodeQL は Phase 3 (#20) で別 PR。

### 既存 shell の clean 確認

`tr -d '\r' < <script> | shellcheck -S warning -` で全 script (init-project.sh / setup-hooks.sh / sync-labels.sh / pre-commit / commit-msg / security-scan.sh) が **0 警告** であることを手元で確認済。CI (Linux runner) では LF のみなので同等に pass する想定。

Closes #19

## Test plan

- [ ] CI: `security` workflow の3 job (gitleaks / trivy / shellcheck) すべて SUCCESS
- [ ] Trivy 動作確認: 実際の dep を scan して noise が出ない（Phase 1 当初は dep なし）
- [ ] shellcheck 動作確認: 既存 6 スクリプトすべて pass
- [ ] dummy PR で `eval`/`curl|sh`/`chmod 777` 含む shell を投入 → shellcheck で fail することを確認、close

🤖 Generated with [Claude Code](https://claude.com/claude-code)