### PR TITLE
fix(ci): use existing semgrep pack r/bash (p/shell does not exist)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,12 +55,14 @@ jobs:
           cache: 'pip'
           cache-dependency-path: .github/workflows/requirements-semgrep.txt
       - run: pip install -r .github/workflows/requirements-semgrep.txt
-      # p/shell: eval / curl|sh / chmod 777 等の shell security pattern
+      # r/bash: curl-pipe-bash (curl|sh) / curl-eval / ifs-tampering 等の bash security
       # p/secrets: hardcoded credential pattern (gitleaks の取りこぼし補完)
+      # 注: semgrep registry に p/shell pack は存在しないため r/bash を使用。
+      # eval "$1" 単体 / chmod 777 のルールは現状なし（必要なら custom rule で追加）
       # WARNING 以上で fail。INFO はノイズ抑制で抜く
       - run: |
           semgrep scan \
-            --config p/shell \
+            --config r/bash \
             --config p/secrets \
             --error \
             --severity=WARNING \

--- a/docs/handoff/bootstrap.md
+++ b/docs/handoff/bootstrap.md
@@ -34,7 +34,7 @@ sh scripts/init-project.sh "<new-pj>" "短い説明"
 
 ### Security CI（自動）
 
-`.github/workflows/security.yml` で **gitleaks**（secret）/ **Trivy**（dep vuln + IaC misconfig、HIGH/CRITICAL のみ）/ **shellcheck**（shell lint、warning level）/ **semgrep**（`p/shell` + `p/secrets`、shell security policy）を並列実行。`.github/dependabot.yml`（npm + github-actions weekly）も併走。
+`.github/workflows/security.yml` で **gitleaks**（secret）/ **Trivy**（dep vuln + IaC misconfig、HIGH/CRITICAL のみ）/ **shellcheck**（shell lint、warning level）/ **semgrep**（`r/bash` + `p/secrets`、bash security + secret pattern）を並列実行。`.github/dependabot.yml`（npm + github-actions weekly）も併走。
 
 ローカルで同等 scan するには `sh scripts/security-scan.sh --all`（各ツール個別実行は `--trivy` / `--shellcheck` / `--semgrep` 等）。public 化前は [`docs/security/public-release-checklist.md`](../security/public-release-checklist.md) を必ず通す。
 

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -8,7 +8,7 @@
 #   --history      gitleaks: 全 git history
 #   --trivy        Trivy: fs scan（vuln + misconfig、HIGH/CRITICAL）
 #   --shellcheck   shellcheck: *.sh + shebang 検出 shell ファイル（warning level）
-#   --semgrep      semgrep: p/shell + p/secrets（shell security policy）
+#   --semgrep      semgrep: r/bash + p/secrets（bash security + secret pattern）
 #   --all          gitleaks(--full) + Trivy + shellcheck + semgrep
 #
 # ツール未インストール時:
@@ -77,15 +77,15 @@ _list_shell_files_z() {
 run_semgrep() {
   # docker フォールバック: semgrep CLI 未インストールでも docker があれば走らせる
   if command -v semgrep >/dev/null 2>&1; then
-    echo "[security-scan] semgrep: p/shell + p/secrets (shell security policy)"
-    semgrep scan --config p/shell --config p/secrets \
+    echo "[security-scan] semgrep: r/bash + p/secrets (bash security + secret pattern)"
+    semgrep scan --config r/bash --config p/secrets \
       --error --severity=WARNING --severity=ERROR --metrics=off
     return
   fi
   if command -v docker >/dev/null 2>&1; then
-    echo "[security-scan] semgrep (docker): p/shell + p/secrets"
+    echo "[security-scan] semgrep (docker): r/bash + p/secrets"
     docker run --rm -v "$(pwd):/src" -w /src semgrep/semgrep:1.161.0 \
-      semgrep scan --config p/shell --config p/secrets \
+      semgrep scan --config r/bash --config p/secrets \
       --error --severity=WARNING --severity=ERROR --metrics=off
     return
   fi


### PR DESCRIPTION
Refs #31

## 状況

PR #34 で導入した semgrep job が **全 PR で 404 fail**：

\`\`\`
Error: Failed to download configuration from https://semgrep.dev/c/p/shell HTTP 404.
\`\`\`

semgrep registry に \`p/shell\` pack は存在しなかった（事前確認漏れ）。

## 修正

\`p/shell\` → \`r/bash\` に置換。

| pack | 存在 | 主な検出 |
|---|---|---|
| \`p/shell\` | ❌ 404 | — |
| \`r/bash\` | ✅ | curl-pipe-bash (\`curl \| sh\`) / curl-eval / ifs-tampering 等 |
| \`p/secrets\` | ✅ | hardcoded credential（変更なし） |

## スコープへの影響

Issue #31 が当初想定していた以下は \`r/bash\` に該当ルールがない:

- \`eval "\$1"\` 単体（curl source なし）
- \`chmod 777\`

これらが必要になった時点で custom rule（\`semgrep --config ./custom-rules.yml\`）で追加検討する。本 PR では out of scope。

## 検証

本 PR merge 後、別 dummy PR で \`curl ... | sh\` を含むスクリプトを置き、semgrep job が fail することを確認する。

## Test plan

- [ ] semgrep job が CI で green（既存ファイルに誤検知なし）
- [ ] 別 dummy PR で curl-pipe-bash 検出を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)