### PR TITLE
feat(ci): CodeQL opt-in template

### DIFF
--- a/.github/workflows/codeql.yml.example
+++ b/.github/workflows/codeql.yml.example
@@ -34,6 +34,9 @@ jobs:
   analyze:
     name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
+    # GitHub デフォルトの 6h タイムアウトに任せると、DB 取得失敗等でハングした
+    # 際に Actions ミニッツを大量浪費する。JS/TS で通常 5〜15 分なので 30 分で打ち切る。
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml.example
+++ b/.github/workflows/codeql.yml.example
@@ -1,0 +1,60 @@
+# CodeQL — opt-in template
+#
+# このファイルは拡張子 .example のため GitHub Actions では実行されない。
+# 有効化手順:
+#   1. ファイル名を `codeql.yml.example` → `codeql.yml` に変更
+#   2. languages: 配列を実際のスタックに合わせて編集（下記コメント参照）
+#   3. commit + push で main / PR で自動実行される
+#
+# CodeQL は重い解析（数分〜十数分）。テンプレ展開先のスタックや CI 予算で
+# 必要性を判断すること。Node のみのプロジェクトでは Trivy + semgrep で十分な
+# ケースが多い。
+#
+# 参考:
+#   - https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning
+#   - https://github.com/github/codeql-action
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # weekly full scan（push trigger だけだと差分依存で漏れることがある）
+    - cron: '17 3 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 実際のスタックに合わせて編集する。
+        # 対応 language: cpp, csharp, go, java-kotlin, javascript-typescript,
+        #               python, ruby, swift
+        language: [javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended は誤検知が多いので security-and-quality を default に
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ flowchart TD
 | `.github/workflows/claude-pr-review.yml` | PR 作成時に 5 軸レビュー + Learning notes（後段の classifier step が verdict marker を必ず付与） |
 | `.github/workflows/rework-tracker.yml` | AI review の `changes-requested-major` を検知して `rework: N` を自動加算 |
 | `.github/workflows/security.yml` | gitleaks (secret) / Trivy (vuln+misconfig) / shellcheck (shell lint) / semgrep (shell security policy) を並列実行 |
+| `.github/workflows/codeql.yml.example` | CodeQL opt-in 雛形（重い言語解析が必要なら有効化、手順は public-release-checklist §8） |
 | `.github/dependabot.yml` | npm / github-actions の weekly 更新 |
 | `docs/handoff/` | GitHub Issues ベース handoff 運用ガイド + AI 実行制御 |
 | `docs/decisions/` | ADR ひな形 + 参考 ADR（Issue SoT / Human acceptance / Learning loop） |

--- a/docs/handoff/bootstrap.md
+++ b/docs/handoff/bootstrap.md
@@ -38,6 +38,8 @@ sh scripts/init-project.sh "<new-pj>" "短い説明"
 
 ローカルで同等 scan するには `sh scripts/security-scan.sh --all`（各ツール個別実行は `--trivy` / `--shellcheck` / `--semgrep` 等）。public 化前は [`docs/security/public-release-checklist.md`](../security/public-release-checklist.md) を必ず通す。
 
+CodeQL は **opt-in 雛形**として `.github/workflows/codeql.yml.example` に同梱。重い言語解析が必要な PJ のみリネームして有効化する（手順は public-release-checklist §8）。
+
 ---
 
 ## 2. GitHub App 連携（claude-code-action 必須）

--- a/docs/security/public-release-checklist.md
+++ b/docs/security/public-release-checklist.md
@@ -116,3 +116,18 @@ git ls-files | grep -E '\.(env|pem|key|har)$|credentials|secret'
 - [ ] security workflow（gitleaks / Trivy / shellcheck / semgrep）が PR 毎に走っていること（[`.github/workflows/security.yml`](../../.github/workflows/security.yml)）
 - [ ] dependabot PR が来たらマージ運用
 - [ ] Issue / PR の不審な活動（大量 spam、bot 攻撃）を週次で確認
+
+---
+
+## 8. CodeQL（opt-in）
+
+`.github/workflows/codeql.yml.example` は **デフォルト無効**の雛形。Node のみの PJ では Trivy + semgrep で十分なケースが多い。重い解析（数分〜十数分）が必要な場面で opt-in する。
+
+有効化手順:
+
+1. `.github/workflows/codeql.yml.example` → `codeql.yml` にリネーム
+2. `matrix.language:` をスタックに合わせて編集（cpp / csharp / go / java-kotlin / javascript-typescript / python / ruby / swift）
+3. リポジトリ Settings → Code security → Code scanning が enabled になっていることを確認
+4. push / PR / weekly cron で自動実行される。結果は Security タブで確認
+
+参考: [GitHub Docs — Configuring code scanning](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning)


### PR DESCRIPTION
Closes #20

## Summary

security CI Phase 3。CodeQL を **opt-in 雛形** として同梱。

- `.github/workflows/codeql.yml.example`: 拡張子 `.example` のため自動実行されない
- `github/codeql-action@v3.35.3` SHA pin
- 標準 queries: `security-and-quality`（`security-extended` は誤検知多めのため避ける）
- 有効化手順を `public-release-checklist.md §8` に記載

## なぜ opt-in か

- CodeQL は数分〜十数分かかる重い解析。Node のみの PJ では Trivy + semgrep で十分なケースが多い
- 言語 matrix は PJ ごとに変わる（テンプレ側で固定値を入れると空振りや誤実行を招く）
- 必要な PJ のみリネーム + 編集 + Settings 確認で有効化する pull モデルが安全

## Test plan

- [ ] CI green（`.example` 拡張子のため codeql workflow 自体は走らない、既存の security workflow のみ走る）
- [ ] テンプレ展開後の有効化手順をドキュメントから読み取れること

🤖 Generated with [Claude Code](https://claude.com/claude-code)