### PR TITLE
docs: README フローチャートに security.yml と rework-tracker.yml を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ flowchart TD
     D1 --> E["PR 作成 (status: review-pending)"]
     D2 --> E
     E --> F["claude-pr-review.yml<br/>5 軸レビュー + Learning notes"]
-    E --> G["CI: typecheck / build"]
-    F --> H["Evidence 提出 (status: evidence-required)"]
+    E --> G["security.yml<br/>gitleaks / Trivy / shellcheck / semgrep<br/>+ CI: typecheck / build"]
+    F -->|changes-requested-major| R["rework-tracker.yml<br/>rework: N 自動加算"]
+    R --> C
+    F -->|approved / minor| H["Evidence 提出 (status: evidence-required)"]
     G --> H
     H --> I{"Human 確認<br/>Evidence のみ参照"}
     I -->|OK| J["status: accepted<br/>→ close (人間のみ)"]


### PR DESCRIPTION
## Summary

- `G` ノードを `security.yml`（gitleaks / Trivy / shellcheck / semgrep）+ project CI に更新
- `F` → `changes-requested-major` → `rework-tracker.yml` → `C` の分岐を追加
- `F` → `H` の矢印を `approved / minor` 条件付きに変更

CI 追加後もフローチャートが更新されておらず、`security.yml` と rework-tracker の連携が図に現れていなかった。

Closes #39

## Test plan

- [ ] GitHub 上で README の mermaid が正しく描画される
- [ ] `rework-tracker.yml` ノードと `changes-requested-major` ラベルが図中に見える
- [ ] `security.yml` の4スキャナーがノードラベルに含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)