### PR TITLE
ci: claude-pr-review に allowed_bots: dependabot[bot] を追加

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
+          # Dependabot 起点 PR を許可（claude-code-action は default で bot を拒否）。
+          # `*` ではなく dependabot 限定。任意 bot からの prompt injection 経路を作らない。
+          allowed_bots: 'dependabot[bot]'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -75,6 +78,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'dependabot[bot]'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- `5-axis review` / `Verdict classifier` 両 step に `allowed_bots: 'dependabot[bot]'` を追加
- 派生 PJ STS2_oekaki_patch で発覚した Dependabot PR fail（`Workflow initiated by non-human actor: dependabot`）の根本対応
- `*` ではなく dependabot 限定で最小許可

Closes #41

## Test plan

- [ ] merge 後、本リポで Dependabot PR が来た時に Claude PR review が green になることを確認
- [ ] 派生 PJ（STS2_oekaki_patch [#15](https://github.com/FUMIHITO-EGUCHI/STS2_oekaki_patch/issues/15)）にも同変更を反映して PR #9 が通ることを確認

## 注意

claude-code-action の制約で workflow 編集は default branch 反映後にしか効かない。merge 完了まで PR ブランチでは旧設定が動く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)