### PR TITLE
fix(ci): grant pull-requests:read to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read  # gitleaks-action calls GET /repos/:owner/:repo/pulls/:n/commits on PR events
 
 jobs:
   gitleaks:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,12 +8,14 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read  # gitleaks-action calls GET /repos/:owner/:repo/pulls/:n/commits on PR events
 
 jobs:
   gitleaks:
     name: gitleaks (secrets)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read  # gitleaks-action calls GET /repos/:owner/:repo/pulls/:n/commits on PR events
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- `gitleaks-action` が PR scan 時に叩く `GET /repos/:owner/:repo/pulls/:n/commits` が template 由来の権限不足で `403 Resource not accessible by integration` で失敗する
- `.github/workflows/security.yml` の top-level `permissions:` に `pull-requests: read` を 1 行追加するだけの修正
- `push` event 経路の挙動は不変

## 実例（downstream）
- [FUMIHITO-EGUCHI/godot-ai-walker#7](https://github.com/FUMIHITO-EGUCHI/godot-ai-walker/pull/7) — 同パッチを先に下流で当てて検証済（merged）
- 失敗 run の例: godot-ai-walker [run 25368242064](https://github.com/FUMIHITO-EGUCHI/godot-ai-walker/actions/runs/25368242064/job/74384629669) の `x-accepted-github-permissions: pull_requests=read` レスポンス

## Test plan
- [ ] 本 PR の `security` workflow が green
- [ ] push event 経路（`branches: [main]`）の挙動が変わらないこと

## Out of scope
- 他 workflow（trivy / shellcheck / semgrep）の権限確認は別タスク

📝 [skip-issue]