### PR TITLE
fix(ci): skip claude-* workflows when CLAUDE_CODE_OAUTH_TOKEN is missing

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -10,7 +10,25 @@ permissions:
   id-token: write
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has_token: ${{ steps.check.outputs.has_token }}
+    steps:
+      - id: check
+        env:
+          T: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$T" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN is not configured for this repository — skipping issue triage. Set the secret to enable."
+          fi
+
   triage:
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has_token == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -15,10 +15,30 @@ permissions:
   id-token: write
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has_token: ${{ steps.check.outputs.has_token }}
+    steps:
+      - id: check
+        env:
+          T: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$T" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN is not configured for this repository — skipping @claude responder. Set the secret to enable."
+          fi
+
   respond:
+    needs: check-secrets
     if: |
-      (github.event.comment != null && contains(github.event.comment.body, '@claude')) ||
-      (github.event.action == 'assigned' && github.event.assignee.login == 'claude')
+      needs.check-secrets.outputs.has_token == 'true' &&
+      (
+        (github.event.comment != null && contains(github.event.comment.body, '@claude')) ||
+        (github.event.action == 'assigned' && github.event.assignee.login == 'claude')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -10,8 +10,25 @@ permissions:
   id-token: write
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has_token: ${{ steps.check.outputs.has_token }}
+    steps:
+      - id: check
+        env:
+          T: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$T" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN is not configured for this repository — skipping AI review. Set the secret to enable."
+          fi
+
   review:
-    if: github.event.pull_request.draft == false
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has_token == 'true' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- 本 template から bootstrap した直後の repo は `CLAUDE_CODE_OAUTH_TOKEN` secret が未設定のため、`anthropics/claude-code-action@v1` が `Environment variable validation failed` で異常終了する
- 該当 3 workflow に `check-secrets` job を追加して secret の有無を検査、無ければ実 job を skip + `::warning::` で通知
- secret 設定済み repo の挙動は不変

## 影響範囲

| Workflow | gated job | trigger |
|---|---|---|
| `claude-pr-review.yml` | `review`（5-axis review + Verdict classifier 2 step） | `pull_request` |
| `claude-mention.yml` | `respond` | issue/PR comment, issue assigned |
| `claude-issue-triage.yml` | `triage` | issue opened |

各 workflow の冒頭に `check-secrets` job を追加し、既存 job は `needs: check-secrets` + `if: needs.check-secrets.outputs.has_token == 'true'` で gate。

## 実例（downstream）
- [FUMIHITO-EGUCHI/godot-ai-walker#8](https://github.com/FUMIHITO-EGUCHI/godot-ai-walker/pull/8) — 同パッチを先に下流で当てて検証済（merged）

## Test plan
- [ ] secret 未設定の本 repo（template）で本 PR の CI が green（review が skip され `::warning::` が出る）
- [ ] secret 設定済み downstream repo で従来どおり AI step が動作（同パッチが merged 済の godot-ai-walker で検証可能）

## Out of scope
- secret 設定手順の README 追記は別タスク
- `App token exchange failed: 401` の race（secret に値はあるが token 無効）は本 gate で捕まえない既知制約。`continue-on-error` 化は副作用大のため別途検討
- `security.yml` の `pull-requests:read` 権限不足は別 PR (#46) で対応中

📝 [skip-issue]