### PR TITLE
ci: CLAUDE_CODE_OAUTH_TOKEN を Environment secret 化（env: claude）

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    environment: claude  # CLAUDE_CODE_OAUTH_TOKEN は env: claude に格納
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -20,6 +20,7 @@ jobs:
       (github.event.comment != null && contains(github.event.comment.body, '@claude')) ||
       (github.event.action == 'assigned' && github.event.assignee.login == 'claude')
     runs-on: ubuntu-latest
+    environment: claude  # CLAUDE_CODE_OAUTH_TOKEN は env: claude に格納
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -13,6 +13,7 @@ jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    environment: claude  # CLAUDE_CODE_OAUTH_TOKEN は env: claude に格納
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/handoff/bootstrap.md
+++ b/docs/handoff/bootstrap.md
@@ -56,6 +56,19 @@ CodeQL は **opt-in 雛形**として `.github/workflows/codeql.yml.example` に
 - GitHub App が当該リポに install される
 - リポジトリ Secret に `CLAUDE_CODE_OAUTH_TOKEN` が自動登録される
 
+### Environment secret 化（推奨）
+
+template の workflow は `environment: claude` を指定しており、`CLAUDE_CODE_OAUTH_TOKEN` を Environment secret として参照する。`/install-github-app` の自動登録は repository secret なので、手動で env に移す:
+
+1. GitHub UI で `Settings → Environments → New environment` → 名前 `claude`
+2. Protection rules は付けない（branch 制限・approval を入れると bot/PR トリガーで自動レビューが止まる）
+3. `Environment secrets` で `CLAUDE_CODE_OAUTH_TOKEN` を追加（値は repo-level secret から copy）
+4. 動作確認後、repo-level の `CLAUDE_CODE_OAUTH_TOKEN` を削除
+
+集約のメリット:
+- 将来 `ANTHROPIC_API_KEY` 等を追加する時に Claude 関連 secret を1箇所にまとめられる
+- env 単位で閲覧/編集権限を分離できる
+
 ### 注意: 自動生成される workflow を削除
 
 `/install-github-app` は副作用として **`.github/workflows/claude-code-review.yml` を勝手に作る**（汎用 PR レビュー workflow）。本テンプレの `claude-pr-review.yml` と機能が重複するため削除する:


### PR DESCRIPTION
## Summary

- `claude-issue-triage.yml` / `claude-mention.yml` / `claude-pr-review.yml` の各 job に `environment: claude` を追加
- `docs/handoff/bootstrap.md` §2 に env 作成手順を追記
- 保護ルール（branch 制限・approval）は付けない方針（自動レビュー停止防止）

Closes #48

## Test plan

- [ ] merge 前: GitHub UI で `claude` environment を作成し `CLAUDE_CODE_OAUTH_TOKEN` を env secret として登録
- [ ] merge 後: 次の PR でレビュー workflow が green
- [ ] 派生 PJ（x-post-archive-extension / STS2_oekaki_patch / godot-ai-walker / translation-platform / tech-articles）にも順次反映

## 注意

claude-code-action の制約で workflow 編集は default branch 反映後にしか効かない。merge 完了まで PR ブランチでは旧設定（repo-level secret 参照）が動く。env を先に作成しておけば repo-level secret は不要だが、移行期間中は両方残しておくのが安全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)