### PR TITLE
fix(ci): grant actions:read to claude-* workflows

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   issues: write
   id-token: write
+  actions: read  # claude-code-action queries GET /repos/:o/:r/actions/runs to attach job links
 
 jobs:
   check-secrets:

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -13,6 +13,7 @@ permissions:
   issues: write
   pull-requests: write
   id-token: write
+  actions: read  # claude-code-action queries GET /repos/:o/:r/actions/runs to attach job links
 
 jobs:
   check-secrets:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: write
   id-token: write
+  actions: read  # claude-code-action queries GET /repos/:o/:r/actions/runs to attach job links
 
 jobs:
   check-secrets:


### PR DESCRIPTION
## Summary
`anthropics/claude-code-action@v1` が PR/Issue イベント中に `GET /repos/:owner/:repo/actions/runs?per_page=1` を叩いて progress コメントに "View job" リンクを貼ろうとするが、template 由来の claude-* 3 workflow では `actions: read` 権限が不足しており 403 で失敗する。

```
GET /repos/:owner/:repo/actions/runs?per_page=1 - 403
  Resource not accessible by integration
```

3 file の top-level `permissions:` ブロックに `actions: read` を 1 行追加するだけの修正。

## 系譜（template 由来の権限地雷シリーズ）

| # | 対象 | upstream tool | 不足 scope |
|---|---|---|---|
| #46 (merged 想定) | `security.yml` | `gitleaks-action` | `pull-requests: read` |
| 本 PR | claude-* 3 workflow | `anthropics/claude-code-action@v1` | `actions: read` |

両方とも template から bootstrap した直後の repo が必ず踏む地雷。

## 実例（downstream）
- [FUMIHITO-EGUCHI/godot-ai-walker#15](https://github.com/FUMIHITO-EGUCHI/godot-ai-walker/pull/15) — 同パッチを下流で当てて検証済（merged）
- 失敗 run: godot-ai-walker [run 25418844373 / job 74557197182](https://github.com/FUMIHITO-EGUCHI/godot-ai-walker/actions/runs/25418844373/job/74557197182?pr=14)

## Test plan
- [ ] 本 PR で `claude-pr-review` が走り、`actions/runs?per_page=1` の 403 が消えること
- [ ] push (main) 経路の挙動が変わらないこと（read 追加のみで縮小していない）

## Out of scope
- `SDK execution error: Claude Code native binary not found ...` の方は claude-code-action 側の install 不安定性（一過性）で本 PR では触らない

📝 [skip-issue]