### PR TITLE
test: actions:read 修正の検証（workflow 非編集 PR）

### DIFF
--- a/docs/findings/2026-05-06-actions-read-permission-verification.md
+++ b/docs/findings/2026-05-06-actions-read-permission-verification.md
@@ -1,0 +1,25 @@
+---
+date: 2026-05-06
+related-issue: PR #50
+status: open
+---
+
+# `actions: read` 権限追加の検証
+
+## 背景
+
+claude-code-action が job link を attach する目的で `GET /repos/:owner/:repo/actions/runs` を叩く。default の `GITHUB_TOKEN` 権限が read-only な repo では 403 になる可能性があり、PR #50 で 3つの claude-* workflow に `actions: read` を追加した。
+
+PR #50 自身は workflow file を編集する PR のため `claude-code-action` の workflow validation で 401 になる（既知制約・bootstrap.md §3）。よって PR #50 自体では検証できない。
+
+本 finding は workflow file を一切編集しない別 PR を立て、`claude-pr-review.yml` が main の workflow（`actions: read` 追加版）で正常完走するかを観測する目的で作成した。
+
+## 期待結果
+
+- `claude-pr-review.yml` の `review` job が SUCCESS
+- 5軸レビューと verdict classifier が完走
+- `actions: read` 不足による 403 が出ない
+
+## 実測
+
+（merge 後の追記欄。検証完了後に結果を書き戻す）


### PR DESCRIPTION
## Summary

PR #50 で claude-* workflow に `actions: read` を追加したが、PR #50 自身は workflow を編集するため `claude-code-action` の workflow validation で 401 になり検証不能。

本 PR は workflow を**一切触らない** trivial 変更（findings 追加のみ）で、main に乗った `actions: read` 修正の動作確認をする。

## Test plan

- [ ] `claude-pr-review.yml` の `review` job が SUCCESS
- [ ] 5軸レビューコメントが投稿される
- [ ] verdict classifier が verdict marker を投稿する
- [ ] `actions: read` 不足による 403 が出ない

検証完了後、findings ファイルに結果を追記して別 PR で merge する。本 PR 自体は merge せず close でも可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)