### PR TITLE
[codex] harden Claude workflow permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Workflow changes can alter repository credentials and CI execution paths.
+.github/ @FUMIHITO-EGUCHI

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -4,15 +4,12 @@ on:
   issues:
     types: [opened]
 
-permissions:
-  contents: read
-  issues: write
-  id-token: write
-  actions: read  # claude-code-action queries GET /repos/:o/:r/actions/runs to attach job links
+permissions: {}
 
 jobs:
   check-secrets:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       has_token: ${{ steps.check.outputs.has_token }}
     steps:
@@ -32,6 +29,11 @@ jobs:
     if: needs.check-secrets.outputs.has_token == 'true'
     runs-on: ubuntu-latest
     environment: claude  # CLAUDE_CODE_OAUTH_TOKEN は env: claude に格納
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+      actions: read  # claude-code-action queries GET /repos/:o/:r/actions/runs to attach job links
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -8,18 +8,16 @@ on:
   issues:
     types: [assigned]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  id-token: write
-  actions: read  # claude-code-action queries GET /repos/:o/:r/actions/runs to attach job links
+permissions: {}
 
 jobs:
-  check-secrets:
+  preflight:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       has_token: ${{ steps.check.outputs.has_token }}
+      trusted_context: ${{ steps.trust.outputs.trusted_context }}
     steps:
       - id: check
         env:
@@ -32,16 +30,52 @@ jobs:
             echo "::warning::CLAUDE_CODE_OAUTH_TOKEN is not configured for this repository — skipping @claude responder. Set the secret to enable."
           fi
 
+      - id: trust
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_IS_PR: ${{ github.event.issue.pull_request != null }}
+          REVIEW_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+
+          trusted=true
+
+          if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
+            if [ "$REVIEW_HEAD_REPO" != "$REPO" ]; then
+              trusted=false
+            fi
+          elif [ "$EVENT_NAME" = "issue_comment" ] && [ "$ISSUE_IS_PR" = "true" ]; then
+            head_repo="$(gh api "repos/$REPO/pulls/$ISSUE_NUMBER" --jq '.head.repo.full_name')"
+            if [ "$head_repo" != "$REPO" ]; then
+              trusted=false
+            fi
+          fi
+
+          echo "trusted_context=$trusted" >> "$GITHUB_OUTPUT"
+          if [ "$trusted" != "true" ]; then
+            echo "::warning::Skipping @claude responder for external fork PR context."
+          fi
+
   respond:
-    needs: check-secrets
+    needs: preflight
     if: |
-      needs.check-secrets.outputs.has_token == 'true' &&
+      needs.preflight.outputs.has_token == 'true' &&
+      needs.preflight.outputs.trusted_context == 'true' &&
       (
         (github.event.comment != null && contains(github.event.comment.body, '@claude')) ||
         (github.event.action == 'assigned' && github.event.assignee.login == 'claude')
       )
     runs-on: ubuntu-latest
     environment: claude  # CLAUDE_CODE_OAUTH_TOKEN は env: claude に格納
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+      actions: read  # claude-code-action queries GET /repos/:o/:r/actions/runs to attach job links
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -4,15 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: read
-  pull-requests: write
-  id-token: write
-  actions: read  # claude-code-action queries GET /repos/:o/:r/actions/runs to attach job links
+permissions: {}
 
 jobs:
   check-secrets:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       has_token: ${{ steps.check.outputs.has_token }}
     steps:
@@ -29,9 +26,17 @@ jobs:
 
   review:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has_token == 'true' && github.event.pull_request.draft == false
+    if: |
+      needs.check-secrets.outputs.has_token == 'true' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: claude  # CLAUDE_CODE_OAUTH_TOKEN は env: claude に格納
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read  # claude-code-action queries GET /repos/:o/:r/actions/runs to attach job links
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Move Claude workflow permissions from workflow scope to job scope.
- Skip high-privilege Claude PR review and mention responders for external fork PR contexts.
- Add CODEOWNERS coverage for `.github/` changes so workflow edits require owner review.

## Why

Mini Shai-Hulud showed that the dangerous shape is untrusted PR-controlled execution reaching privileged CI context, cache, or OIDC credentials. This keeps normal internal development flows working while reducing the blast radius for external fork PRs.

## Validation

- Parsed the changed workflow YAML files successfully.
- Ran `git diff --check` with no whitespace errors.
- Confirmed no `pull_request_target` trigger was added and `id-token: write` is now job-scoped in the Claude workflows.

Note: `actionlint` was not run because the npm package invocation available in this environment could not resolve an executable.